### PR TITLE
Fix install script BASH_SOURCE error when piped to bash

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 
 # 🚀 Picovis CLI Universal Installation Script
-# 
+#
 # This script automatically detects your operating system and architecture,
 # downloads the appropriate Picovis CLI binary from GitHub releases, and
 # installs it to your system.
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/picovis/picovis-community/main/scripts/install.sh | bash
-#   curl -fsSL https://raw.githubusercontent.com/picovis/picovis-community/main/scripts/install.sh | bash -s -- --version=v1.2.3
-#   curl -fsSL https://raw.githubusercontent.com/picovis/picovis-community/main/scripts/install.sh | bash -s -- --prefix=/opt/picovis
+#   curl -fsSL https://raw.githubusercontent.com/picovis/picovis-community/main/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/picovis/picovis-community/main/install.sh | bash -s -- --version=v1.2.3
+#   curl -fsSL https://raw.githubusercontent.com/picovis/picovis-community/main/install.sh | bash -s -- --prefix=/opt/picovis
 #
 # Options:
 #   --version=VERSION    Install specific version (default: latest)
@@ -75,34 +75,34 @@ log_header() {
 
 # 🆘 Help function
 show_help() {
-    cat << EOF
+    cat <<EOF
 ${BOLD}Picovis CLI Installation Script${NC}
 
 ${BOLD}USAGE:${NC}
-    curl -fsSL https://raw.githubusercontent.com/picovis/picovis-community/main/scripts/install.sh | bash
-    curl -fsSL https://raw.githubusercontent.com/picovis/picovis-community/main/scripts/install.sh | bash -s -- [OPTIONS]
+    curl -fsSL https://raw.githubusercontent.com/picovis/picovis-community/main/install.sh | bash
+    curl -fsSL https://raw.githubusercontent.com/picovis/picovis-community/main/install.sh | bash -s -- [OPTIONS]
 
 ${BOLD}OPTIONS:${NC}
     --version=VERSION    Install specific version (e.g., --version=v1.2.3)
                         Default: latest
-    
+
     --prefix=PREFIX      Install to custom directory (e.g., --prefix=/opt/picovis)
                         Default: /usr/local
                         Binary will be installed to PREFIX/bin/picovis
-    
+
     --force              Force reinstallation even if already installed
-    
+
     --help               Show this help message
 
 ${BOLD}EXAMPLES:${NC}
     # Install latest version to /usr/local/bin
-    curl -fsSL https://raw.githubusercontent.com/picovis/picovis-community/main/scripts/install.sh | bash
+    curl -fsSL https://raw.githubusercontent.com/picovis/picovis-community/main/install.sh | bash
 
     # Install specific version
-    curl -fsSL https://raw.githubusercontent.com/picovis/picovis-community/main/scripts/install.sh | bash -s -- --version=v1.2.3
+    curl -fsSL https://raw.githubusercontent.com/picovis/picovis-community/main/install.sh | bash -s -- --version=v1.2.3
 
     # Install to custom directory
-    curl -fsSL https://raw.githubusercontent.com/picovis/picovis-community/main/scripts/install.sh | bash -s -- --prefix=\$HOME/.local
+    curl -fsSL https://raw.githubusercontent.com/picovis/picovis-community/main/install.sh | bash -s -- --prefix=\$HOME/.local
 
 ${BOLD}SUPPORTED PLATFORMS:${NC}
     • Linux x64
@@ -116,43 +116,43 @@ EOF
 # 🔍 Platform detection
 detect_platform() {
     log_progress "Detecting platform and architecture..."
-    
+
     # Detect OS
     case "$(uname -s)" in
-        Linux*)
-            DETECTED_OS="linux"
-            ;;
-        Darwin*)
-            DETECTED_OS="macos"
-            ;;
-        *)
-            log_error "Unsupported operating system: $(uname -s)"
-            log_info "Supported platforms: Linux, macOS"
-            exit 1
-            ;;
+    Linux*)
+        DETECTED_OS="linux"
+        ;;
+    Darwin*)
+        DETECTED_OS="macos"
+        ;;
+    *)
+        log_error "Unsupported operating system: $(uname -s)"
+        log_info "Supported platforms: Linux, macOS"
+        exit 1
+        ;;
     esac
-    
+
     # Detect architecture
     case "$(uname -m)" in
-        x86_64|amd64)
-            DETECTED_ARCH="x64"
-            ;;
-        arm64|aarch64)
-            if [[ "$DETECTED_OS" == "macos" ]]; then
-                DETECTED_ARCH="arm64"
-            else
-                log_error "ARM64 architecture is only supported on macOS"
-                log_info "For Linux, please use x64 architecture"
-                exit 1
-            fi
-            ;;
-        *)
-            log_error "Unsupported architecture: $(uname -m)"
-            log_info "Supported architectures: x86_64 (x64), arm64 (macOS only)"
+    x86_64 | amd64)
+        DETECTED_ARCH="x64"
+        ;;
+    arm64 | aarch64)
+        if [[ "$DETECTED_OS" == "macos" ]]; then
+            DETECTED_ARCH="arm64"
+        else
+            log_error "ARM64 architecture is only supported on macOS"
+            log_info "For Linux, please use x64 architecture"
             exit 1
-            ;;
+        fi
+        ;;
+    *)
+        log_error "Unsupported architecture: $(uname -m)"
+        log_info "Supported architectures: x86_64 (x64), arm64 (macOS only)"
+        exit 1
+        ;;
     esac
-    
+
     BINARY_FILENAME="picovis-${DETECTED_OS}-${DETECTED_ARCH}"
     log_success "Detected platform: ${DETECTED_OS}-${DETECTED_ARCH}"
 }
@@ -160,22 +160,22 @@ detect_platform() {
 # 🔗 Get download URL
 get_download_url() {
     log_progress "Resolving download URL..."
-    
+
     if [[ "$INSTALL_VERSION" == "latest" ]]; then
         log_info "Fetching latest release information..."
         local latest_release
         latest_release=$(curl -fsSL "https://api.github.com/repos/${GITHUB_REPO}/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
-        
+
         if [[ -z "$latest_release" ]]; then
             log_error "Failed to fetch latest release information"
             log_info "Please specify a version manually with --version=vX.Y.Z"
             exit 1
         fi
-        
+
         INSTALL_VERSION="$latest_release"
         log_success "Latest version: $INSTALL_VERSION"
     fi
-    
+
     DOWNLOAD_URL="https://github.com/${GITHUB_REPO}/releases/download/${INSTALL_VERSION}/${BINARY_FILENAME}"
     log_success "Download URL: $DOWNLOAD_URL"
 }
@@ -183,11 +183,11 @@ get_download_url() {
 # 📥 Download binary
 download_binary() {
     log_progress "Downloading Picovis CLI binary..."
-    
+
     # Create temporary directory
     mkdir -p "$TEMP_DIR"
     local temp_binary="$TEMP_DIR/$BINARY_FILENAME"
-    
+
     # Download with progress
     if command -v curl >/dev/null 2>&1; then
         if ! curl -fL --progress-bar "$DOWNLOAD_URL" -o "$temp_binary"; then
@@ -200,16 +200,16 @@ download_binary() {
         log_info "Please install curl and try again"
         exit 1
     fi
-    
+
     # Verify download
     if [[ ! -f "$temp_binary" ]] || [[ ! -s "$temp_binary" ]]; then
         log_error "Downloaded binary is empty or missing"
         exit 1
     fi
-    
+
     # Make executable
     chmod +x "$temp_binary"
-    
+
     log_success "Binary downloaded successfully"
     echo "$temp_binary"
 }
@@ -219,9 +219,9 @@ install_binary() {
     local temp_binary="$1"
     local install_dir="$INSTALL_PREFIX/bin"
     local install_path="$install_dir/$BINARY_NAME"
-    
+
     log_progress "Installing Picovis CLI to $install_path..."
-    
+
     # Create install directory if it doesn't exist
     if [[ ! -d "$install_dir" ]]; then
         log_info "Creating directory: $install_dir"
@@ -233,14 +233,14 @@ install_binary() {
             fi
         fi
     fi
-    
+
     # Check if already installed and not forcing
     if [[ -f "$install_path" ]] && [[ "$FORCE_INSTALL" == false ]]; then
         local current_version
         current_version=$("$install_path" --version 2>/dev/null | head -n1 || echo "unknown")
         log_warning "Picovis CLI is already installed: $current_version"
         log_info "Use --force to reinstall or uninstall first"
-        
+
         # Ask user if they want to continue
         echo -n "Do you want to continue with installation? [y/N]: "
         read -r response
@@ -249,7 +249,7 @@ install_binary() {
             exit 0
         fi
     fi
-    
+
     # Install binary
     if ! cp "$temp_binary" "$install_path" 2>/dev/null; then
         log_warning "Permission denied. Trying with sudo..."
@@ -257,34 +257,34 @@ install_binary() {
             log_error "Failed to install binary to $install_path"
             exit 1
         fi
-        
+
         # Ensure correct permissions
         sudo chmod 755 "$install_path"
         sudo chown root:root "$install_path" 2>/dev/null || true
     else
         chmod 755 "$install_path"
     fi
-    
+
     log_success "Picovis CLI installed to $install_path"
 }
 
 # ✅ Verify installation
 verify_installation() {
     local install_path="$INSTALL_PREFIX/bin/$BINARY_NAME"
-    
+
     log_progress "Verifying installation..."
-    
+
     # Check if binary exists and is executable
     if [[ ! -f "$install_path" ]]; then
         log_error "Binary not found at $install_path"
         exit 1
     fi
-    
+
     if [[ ! -x "$install_path" ]]; then
         log_error "Binary is not executable: $install_path"
         exit 1
     fi
-    
+
     # Test binary execution
     local version_output
     if ! version_output=$("$install_path" --version 2>&1); then
@@ -292,7 +292,7 @@ verify_installation() {
         log_info "Output: $version_output"
         exit 1
     fi
-    
+
     log_success "Installation verified successfully"
     log_info "Version: $version_output"
 }
@@ -300,7 +300,7 @@ verify_installation() {
 # 🛣️ Check PATH
 check_path() {
     local install_dir="$INSTALL_PREFIX/bin"
-    
+
     if [[ ":$PATH:" != *":$install_dir:"* ]]; then
         log_warning "Install directory is not in your PATH: $install_dir"
         log_info "Add the following line to your shell profile (~/.bashrc, ~/.zshrc, etc.):"
@@ -322,27 +322,27 @@ cleanup() {
 parse_args() {
     while [[ $# -gt 0 ]]; do
         case $1 in
-            --version=*)
-                INSTALL_VERSION="${1#*=}"
-                shift
-                ;;
-            --prefix=*)
-                INSTALL_PREFIX="${1#*=}"
-                shift
-                ;;
-            --force)
-                FORCE_INSTALL=true
-                shift
-                ;;
-            --help)
-                show_help
-                exit 0
-                ;;
-            *)
-                log_error "Unknown option: $1"
-                log_info "Use --help for usage information"
-                exit 1
-                ;;
+        --version=*)
+            INSTALL_VERSION="${1#*=}"
+            shift
+            ;;
+        --prefix=*)
+            INSTALL_PREFIX="${1#*=}"
+            shift
+            ;;
+        --force)
+            FORCE_INSTALL=true
+            shift
+            ;;
+        --help)
+            show_help
+            exit 0
+            ;;
+        *)
+            log_error "Unknown option: $1"
+            log_info "Use --help for usage information"
+            exit 1
+            ;;
         esac
     done
 }
@@ -351,25 +351,25 @@ parse_args() {
 main() {
     # Set up cleanup trap
     trap cleanup EXIT
-    
+
     # Show header
     log_header "Picovis CLI Installation"
     echo
-    
+
     # Parse arguments
     parse_args "$@"
-    
+
     # Validate prefix
     if [[ -z "$INSTALL_PREFIX" ]]; then
         log_error "Install prefix cannot be empty"
         exit 1
     fi
-    
+
     # Show installation info
     log_info "Installation version: $INSTALL_VERSION"
     log_info "Installation prefix: $INSTALL_PREFIX"
     echo
-    
+
     # Run installation steps
     detect_platform
     get_download_url
@@ -378,7 +378,7 @@ main() {
     install_binary "$temp_binary"
     verify_installation
     check_path
-    
+
     # Success message
     echo
     log_header "Installation Complete! 🎉"
@@ -390,6 +390,7 @@ main() {
 }
 
 # Run main function if script is executed directly
-if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+# Handle both direct execution and piped execution (e.g., curl | bash)
+if [[ "${BASH_SOURCE[0]:-}" == "${0}" ]] || [[ -z "${BASH_SOURCE[0]:-}" ]]; then
     main "$@"
 fi


### PR DESCRIPTION
## Problem

The installation command in the README fails with the error:
```
bash: line 393: BASH_SOURCE[0]: unbound variable
```

This occurs when running:
```bash
curl -fsSL https://raw.githubusercontent.com/picovis/picovis-community/main/install.sh | bash
```

## Root Cause

The script uses `BASH_SOURCE[0]` to check if it's being executed directly, but when piped to bash, this variable is not set, causing an "unbound variable" error due to the `set -euo pipefail` setting.

## Solution

- **Fixed BASH_SOURCE handling**: Use parameter expansion with default value `${BASH_SOURCE[0]:-}` to handle both direct execution and piped execution
- **Updated condition**: Check if `BASH_SOURCE[0]` is unset to properly handle piped execution
- **Fixed documentation**: Corrected script comments that incorrectly referenced `scripts/install.sh` instead of `install.sh`

## Changes

### Before:
```bash
if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
    main "$@"
fi
```

### After:
```bash
# Handle both direct execution and piped execution (e.g., curl | bash)
if [[ "${BASH_SOURCE[0]:-}" == "${0}" ]] || [[ -z "${BASH_SOURCE[0]:-}" ]]; then
    main "$@"
fi
```

## Testing

✅ Tested with direct execution: `bash install.sh --help`
✅ Tested with piped execution: `cat install.sh | bash -s -- --help`
✅ Both methods work without errors

## Impact

This fix resolves the installation issue for users with fish shell and other environments where the original curl command was failing.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author